### PR TITLE
refactor: Improvements without the need of a tree listener, as it is …

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,10 +43,10 @@ jobs:
 
       # Setup Java 11 environment for the next steps
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 11
+          java-version: 17
           cache: gradle
 
       # Set environment variables

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,11 +35,11 @@ jobs:
 
       # Check out current repository
       - name: Fetch Sources
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v4.1.1
 
       # Validate wrapper
       - name: Gradle Wrapper Validation
-        uses: gradle/wrapper-validation-action@v1.0.4
+        uses: gradle/wrapper-validation-action@v1.1.0
 
       # Setup Java 11 environment for the next steps
       - name: Setup Java
@@ -76,14 +76,14 @@ jobs:
       # Collect Tests Result of failed tests
       - name: Collect Tests Result
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4.1.0
         with:
           name: tests-result
           path: ${{ github.workspace }}/build/reports/tests
 
       # Cache Plugin Verifier IDEs
       - name: Setup Plugin Verifier IDEs Cache
-        uses: actions/cache@v2.1.7
+        uses: actions/cache@v4.0.0
         with:
           path: ${{ steps.properties.outputs.pluginVerifierHomeDir }}/ides
           key: plugin-verifier-${{ hashFiles('build/listProductsReleases.txt') }}
@@ -95,14 +95,14 @@ jobs:
       # Collect Plugin Verifier Result
       - name: Collect Plugin Verifier Result
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4.1.0
         with:
           name: pluginVerifier-result
           path: ${{ github.workspace }}/build/reports/pluginVerifier
 
       # Run Qodana inspections
       - name: Qodana - Code Inspection
-        uses: JetBrains/qodana-action@v4.2.5
+        uses: JetBrains/qodana-action@v2023.3.0
 
       # Prepare plugin archive content for creating artifact
       - name: Prepare Plugin Artifact
@@ -117,7 +117,7 @@ jobs:
 
       # Store already-built plugin as an artifact for downloading
       - name: Upload artifact
-        uses: actions/upload-artifact@v2.2.4
+        uses: actions/upload-artifact@v4.1.0
         with:
           name: ${{ steps.artifact.outputs.filename }}
           path: ./build/distributions/content/*/*
@@ -133,7 +133,7 @@ jobs:
 
       # Check out current repository
       - name: Fetch Sources
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v4.1.1
 
       # Remove old release drafts by using the curl request for the available releases with draft flag
       - name: Remove Old Release Drafts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
           name: pluginVerifier-result
           path: ${{ github.workspace }}/build/reports/pluginVerifier
 
-      # Run Qodana inspections
+      # Run Qodana inspections // TODO: re-enable
       - name: Qodana - Code Inspection
         uses: JetBrains/qodana-action@v2023.3.0
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -117,9 +117,16 @@ tasks {
     }
 
     runIde {
-        // specify to use local PhpStorm installation
-        // doc is wrong, do not use ideDir = ... because ideDir is read-only
-        ideDir.set(file("/Applications/PhpStorm.app/Contents"))
+        // specify to use local PhpStorm installation if available
+        file("/Applications/PhpStorm.app/Contents").let {
+            // TODO: find a way to understand whether you're in a ci job, then you would not do any of this
+            if (it.isFile) {
+                ideDir.set(it)
+            } else {
+                println("Could not find file at path ${it.path} : Are you inside a CI job?")
+            }
+        }
+
 
         // enable auto-reload when `runIde` is running, and `buildPlugin` is executed
         autoReloadPlugins.set(true)

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,9 +8,7 @@ pluginVersion = 0.0.1
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-# TODO: restore this original value
-#pluginSinceBuild = 211
-pluginSinceBuild = 211
+pluginSinceBuild = 222
 pluginUntilBuild = 233.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,0 +1,2 @@
+# See https://docs.gradle.org/current/userguide/part3_gradle_dep_man.html#step_6_adding_a_version_catalog
+


### PR DESCRIPTION
…officially recommended to not use the tree listener wherever possible

# TLDR;
1. keep using sprintf intention
2. store tree parent of concatenation expression before executing sprintf
3. do not use tree listener, as it is slow, in the docs they say not to use it whenever possible, and it is not needed anymore since we are doing point 2

# Desc
It actually makes sense to remember the previous parent of the statement converted by the `sprintf` intention, as opposed to listen to any tree change and hope to match the correct one. (technically, I was not "hoping" as I was verifying the content of the inserted branch, but you get the idea).


