### PR TITLE
Refactor+fix do not use sprintf

### DIFF
--- a/src/main/kotlin/com/github/tognitos/intellijstringconcatheredocplugin/StringConcatenationToHeredocConverter.kt
+++ b/src/main/kotlin/com/github/tognitos/intellijstringconcatheredocplugin/StringConcatenationToHeredocConverter.kt
@@ -156,11 +156,9 @@ class StringConcatenationToHeredocConverter : PsiElementBaseIntentionAction(), I
                 element,
                 PhpEchoStatementImpl::class.java
             ) ?: return false
-
-
-            // TODO: replace this with Visitor for better performance?
+            
             // if any direct child of the Echo statement is a comma, we are inside an echo with commas
-            return parentEchoStatement.node.getChildren(TokenSet.create(PhpTokenTypes.opCOMMA)).size > 0
+            return parentEchoStatement.node.getChildren(TokenSet.create(PhpTokenTypes.opCOMMA)).isNotEmpty()
         }
 
 

--- a/src/main/kotlin/com/github/tognitos/intellijstringconcatheredocplugin/StringConcatenationToHeredocConverter.kt
+++ b/src/main/kotlin/com/github/tognitos/intellijstringconcatheredocplugin/StringConcatenationToHeredocConverter.kt
@@ -5,23 +5,18 @@ import com.intellij.codeInsight.intention.IntentionAction
 import com.intellij.codeInsight.intention.PsiElementBaseIntentionAction
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.project.getProjectCacheFileName
 import com.intellij.psi.PsiElement
 import com.intellij.psi.tree.TokenSet
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.IncorrectOperationException
-import com.jetbrains.php.codeInsight.PhpScopeHolder
-import com.jetbrains.php.lang.inspections.PhpScopeHolderVisitor
-import com.jetbrains.php.lang.intentions.strings.PhpConvertConcatenationToSprintfIntention
+import com.jetbrains.php.lang.intentions.PhpReplaceQuotesIntention
 import com.jetbrains.php.lang.lexer.PhpTokenTypes
 import com.jetbrains.php.lang.psi.PhpPsiElementFactory
 import com.jetbrains.php.lang.psi.elements.*
 import com.jetbrains.php.lang.psi.elements.impl.PhpEchoStatementImpl
 import com.jetbrains.php.lang.psi.stubs.indexes.PhpDepthLimitedRecursiveElementVisitor
+import io.ktor.http.*
 import java.rmi.UnexpectedException
-import java.util.regex.Pattern
-
-internal class TupleHeredocSprintf(var heredoc: String, var sprintf: FunctionReference)
 
 /**
  * Implements an intention action to replace string concatenations with HEREDOC strings
@@ -60,20 +55,12 @@ class StringConcatenationToHeredocConverter : PsiElementBaseIntentionAction(), I
      * `false` for all other types of caret positions
      */
     override fun isAvailable(project: Project, editor: Editor, element: PsiElement): Boolean {
-        // Quick sanity check
-        if (element == null) {
-            return false
-        }
-
         // TODO: add plugin settings to display intention with minimum amount of concatenation expressions and/or echo commas
+        // TODO consider displaying intention only if expressions are present
 
-        // TODO implement for echo calls with a lot of `,` , only if any of the echo statements contain HTML or any expression
         val isConcat = isElementOrAncestorAConcatenation(element)
         val isEchoWithCommas = isElementOrAncestorAEchoWithCommas(element)
-        val available = isConcat || isEchoWithCommas
-        println(element.toString() + " parent: " + element.parent.toString())
-        println("Is available $available (isConcat=$isConcat;isEchoWithCommas=$isEchoWithCommas)")
-        return available
+        return isConcat || isEchoWithCommas
     }
 
     /**
@@ -98,48 +85,40 @@ class StringConcatenationToHeredocConverter : PsiElementBaseIntentionAction(), I
 
         topConcatenation!!
 
-        // will be used to know where to declare variables for fn calls
-        val concatToSprintf = PhpConvertConcatenationToSprintfIntention()
-        if (!concatToSprintf.isAvailable(project, editor, element)) {
-            // TODO : remove this message and maybe the whole condition at all
-            nl()
-            print("------------------------------")
-            println("Sprintf not available, therefore not doing anything: what's the point if concatenation does not contain any expression?")
-            print("------------------------------")
-            nl()
-            return
-
-        }
-
-        val (pre, heredocContent) = runCatching {
-            useVisitor(project, topConcatenation)
+        val (extractedVariableDeclarations, heredocContent) = runCatching {
+            useVisitor(topConcatenation)
         }.onFailure { e ->
-            println("Could not generate hereddoc content: $topConcatenation")
             e.printStackTrace()
             return
         }.getOrThrow()
 
-
-        /*
-         * Structure of heredoc as a StringLiteralExpression:
-         *  - heredoc start (e.g. <<<DELIMITER)
-         *  - heredoc content (e.g. <div>Hi $username</div>)
-         *  - heredoc end (e.g. DELIMITER;)
-         */
-
         // TODO : let user pick delimiter, or choose based on interpreted content (e.g. HTML or JS or SQL)
         val heredocDelimiter = "HEREDOC_DELIMITER"
-        val result = PhpPsiElementFactory.createPhpPsiFromText(
+        val heredocPsi = PhpPsiElementFactory.createPhpPsiFromText(
             project,
             StringLiteralExpression::class.java,
             """
-            $pre
             <<<$heredocDelimiter
             $heredocContent
             $heredocDelimiter;
             """.trimIndent()
         )
-        topConcatenation.replace(result)
+        val topConcatenationStatement = PsiTreeUtil.getParentOfType(topConcatenation, Statement::class.java)!!
+        val storeParent = topConcatenationStatement.parent
+
+        topConcatenation.replace(heredocPsi)
+
+        extractedVariableDeclarations.forEach { preStatementText ->
+            storeParent.let {
+                val preStatementPsi = PhpPsiElementFactory.createStatement(
+                    project,
+                    preStatementText
+                )
+                it.addBefore(
+                    preStatementPsi,
+                    topConcatenationStatement
+                )}
+        }
     }
 
     /**
@@ -182,136 +161,91 @@ class StringConcatenationToHeredocConverter : PsiElementBaseIntentionAction(), I
                 PhpEchoStatementImpl::class.java
             ) ?: return false
 
-            // true = not within Echo
-
-//        PhpElementVisitor commaVisitor = new PhpElementVisitor() {
-//            @Override
-//            public void visitPhpElement(PhpPsiElement element) {
-//                super.visitPhpElement(element);
-//                // if found then throw StopVisitingException
-//            }
-//        };
 
             // TODO: replace this with Visitor for better performance?
             // if any direct child of the Echo statement is a comma, we are inside an echo with commas
             return parentEchoStatement.node.getChildren(TokenSet.create(PhpTokenTypes.opCOMMA)).size > 0
         }
 
-        fun nl() {
-            println("\n")
-        }
-
-        fun findParentStatement(psiElement: PsiElement?): Statement? {
-            if (psiElement == null) {
-                println("psiElement null, will not find parent statement")
-                return null
-            }
-            return PsiTreeUtil.getParentOfType(
-                psiElement,
-                Statement::class.java
-            )
-        }
-
-        fun findChildSprintf(statement: Statement?): FunctionReference? {
-            val functionChildren = PsiTreeUtil.findChildrenOfType(
-                statement,
-                FunctionReference::class.java
-            )
-            for (functionReference in functionChildren) {
-                if (functionReference.name == "sprintf") {
-                    return functionReference
-                }
-            }
-            println("Could not find child of type sprintf, something must have gone wrong")
-            return null
-        }
-
 
         @Throws(UnexpectedException::class)
         private fun useVisitor(
-            project: Project,
             topConcatenation: ConcatenationExpression
-        ): Pair<String, String> {
-            println("useWalker")
-            println("topConcatenation $topConcatenation")
-            println("can modify topConcatenation? ${canModify(topConcatenation)}")
-
-            val pre = StringBuilder()
+        ): Pair<List<String>, String> {
+            val declarations = ArrayList<String>()
             val heredocContent = StringBuilder()
 
             var i = 0;
-            // TODO use PsiRecursiveElementWalkingVisitor to visit all concat parts
-            topConcatenation.acceptChildren(object : PhpDepthLimitedRecursiveElementVisitor() {
+            topConcatenation.accept(object : PhpDepthLimitedRecursiveElementVisitor() {
                 override fun visitPhpElement(element: PhpPsiElement) {
                     super.visitPhpElement(element)
                     i++
-                    println("[PHP EL]visited this element")
-                    println(element)
 
-                    when (element) {
-                        is ConcatenationExpression -> Unit // do nothing, we will visit the children afterward
+                    if (element !is ConcatenationExpression) {
+                        return;
+                    }
 
-                        is StringLiteralExpression -> {
-                            println("matched stringliteralexpression")
-                            heredocContent.append(element.contents)
-                        }
+                    arrayOf(element.leftOperand, element.rightOperand).forEach { concatenationOperand ->
+                        when (concatenationOperand) {
+                            is ConcatenationExpression -> Unit // do nothing, we will visit the children afterward
 
-                        is Variable -> {
-                            println("name identifier of variable " + element.nameIdentifier!!.text)
-                            println("name of variable second try: " + element.nameNode!!.text)
-
-                            // always wrap in curly braces because if some letter follows the variable name in heredoc,
-                            // the wrong variable name will be matched (e.g. $juices vs {$juice}s)
-                            extractNameOfPhpVar(element).let{
-                                // pre.append(it)
-                                heredocContent.append(formatVariableForHeredoc(it))
+                            is StringLiteralExpression -> {
+                                val contentToAppend: String =
+                                    if (concatenationOperand.isSingleQuote) PhpReplaceQuotesIntention.createLiteralWithChangedQuotes(concatenationOperand).contents
+                                    else concatenationOperand.contents
+                                heredocContent.append(contentToAppend)
                             }
-                        }
 
-                        is FieldReference, is ArrayAccessExpression -> {
-                            (element.text).let {
-                                heredocContent.append(formatVariableForHeredoc(it))
+
+                            is Variable -> {
+                                // always wrap in curly braces because if some letter follows the variable name in heredoc,
+                                // the wrong variable name will be matched (e.g. $juices vs {$juice}s)
+                                extractNameOfPhpVar(concatenationOperand).let{
+                                    // pre.append(bla)
+                                    heredocContent.append(formatVariableForHeredoc(it))
+                                }
                             }
-                        }
 
-                        is AssignmentExpression -> {
-                            // add semicolon to the assignment expression, since it did not have it in the string concatenation
-                            pre.append("${element.text};")
-
-                            // append variable name
-                            heredocContent.append(formatVariableForHeredoc(extractNameOfPhpVar(
-                                element.variable as Variable
-                            )))
-                        }
-
-                        is FunctionReference -> {
-                            // if it's function call
-                            // create variable before statement
-                            // assign new variable = the function call
-                            // append name of variable to sb
-                            val newVarName = "\$newVarFnCall$i"
-
-                            // add the whole assignment line before the heredoc
-                            newVarName.let {
-                                pre.append("$newVarName=${element.text};")
-                                heredocContent.append(formatVariableForHeredoc(newVarName))
+                            is FieldReference, is ArrayAccessExpression -> {
+                                (concatenationOperand.text).let {
+                                    heredocContent.append(formatVariableForHeredoc(it))
+                                }
                             }
-                        }
 
-                        is PhpExpression -> {
-                            // same as for FunctionReference, just create a var
+                            is AssignmentExpression -> {
+                                // add semicolon to the assignment expression, because it is missing within a concatenation expression
+                                declarations.add("${concatenationOperand.text};")
 
-                            // TODO use text to create var name?
-                            val newVarName = "\$newVarPhpExpression$i"
-                            newVarName.let {
-                                pre.append("$newVarName=${element.text};")
-                                heredocContent.append(formatVariableForHeredoc(newVarName))
+                                // append variable name
+                                heredocContent.append(formatVariableForHeredoc(extractNameOfPhpVar(
+                                    concatenationOperand.variable as Variable
+                                )))
                             }
-                        }
-                        else -> {
-                            heredocContent.append("I_SHOULD_NOT_APPEAR")
+
+                            is FunctionReference -> {
+                                val newVarName = "\$newVarFnCall$i"
+
+                                // add the whole assignment line before the heredoc
+                                newVarName.let {
+                                    declarations.add("$newVarName=${concatenationOperand.text};")
+                                    heredocContent.append(formatVariableForHeredoc(newVarName))
+                                }
+                            }
+
+                            is PhpExpression -> {
+                                // TODO use text to create var name?
+                                val newVarName = "\$newVarPhpExpression$i"
+                                newVarName.let {
+                                    declarations.add("$newVarName=${concatenationOperand.text};")
+                                    heredocContent.append(formatVariableForHeredoc(newVarName))
+                                }
+                            }
+                            else -> {
+                                heredocContent.append("I_SHOULD_NOT_APPEAR")
+                            }
                         }
                     }
+
                 }
             })
 
@@ -335,7 +269,7 @@ class StringConcatenationToHeredocConverter : PsiElementBaseIntentionAction(), I
             // TODO : do we need the "Marks"?
             // TODO : reformat CONTENT of heredoc based on content type (e.g. format HTML decently if possible)
 
-            return Pair(pre.toString(), heredocContent.toString())
+            return Pair(declarations, heredocContent.toString())
         }
 
         fun extractNameOfPhpVar(variable: Variable): String {

--- a/src/test/kotlin/com/github/tognitos/intellijstringconcatheredocplugin/StringConcatenationToHeredocConverterTest.kt
+++ b/src/test/kotlin/com/github/tognitos/intellijstringconcatheredocplugin/StringConcatenationToHeredocConverterTest.kt
@@ -17,6 +17,7 @@ class StringConcatenationToHeredocConverterTest : BasePlatformTestCase() {
     override fun getTestDataPath() = "src/test/testData/php"
 
     fun doTestIntentionAction(testName: String, hint: String?) {
+
         val beforeSuffix = ".template.before.php"
         val afterSuffix = ".template.after.php"
 
@@ -34,12 +35,17 @@ class StringConcatenationToHeredocConverterTest : BasePlatformTestCase() {
 
     fun testIntention() {
         arrayOf(
+            "templates/concatenation/simple",
+            "templates/concatenation/complex",
             "templates/concatenation/with_escapings",
             "templates/concatenation/within_array",
             "templates/concatenation/within_big_indentation",
 
             // TODO: add a converted echo
-        ).forEach { fileName -> doTestIntentionAction(fileName, StringConcatenationToHeredocConverter.INTENTION_HINT) }
+        ).forEach { fileName ->
+            println("calling doTestIntentionAction for : $fileName")
+            doTestIntentionAction(fileName, StringConcatenationToHeredocConverter.INTENTION_HINT)
+        }
     }
 
     fun testIsNotAvailable() {

--- a/src/test/kotlin/com/github/tognitos/intellijstringconcatheredocplugin/TestCompletion.kt
+++ b/src/test/kotlin/com/github/tognitos/intellijstringconcatheredocplugin/TestCompletion.kt
@@ -3,9 +3,7 @@
  * @see https://github.com/JetBrains/intellij-community/blob/idea/233.14015.106/spellchecker/testSrc/com/intellij/spellchecker/inspector/AcceptWordAsCorrectTest.java
  * @see https://github.com/JetBrains/intellij-community/blob/idea/233.14015.106/java/java-tests/testSrc/com/intellij/copyright/JavaCopyrightTest.kt
  * @see https://github.com/JetBrains/intellij-community/blob/idea/233.14015.106/platform/testFramework/src/com/intellij/testFramework/fixtures/CodeInsightTestFixture.java
- */
-
-/**
+ *
  * An actual real life example `ComparingStringReferencesInspectionTest`
  * @see https://github.com/JetBrains/intellij-sdk-code-samples/blob/main/comparing_string_references_inspection/src/test/java/org/intellij/sdk/codeInspection/ComparingStringReferencesInspectionTest.java
  */

--- a/src/test/testData/php/templates/concatenation/complex.template.after.php
+++ b/src/test/testData/php/templates/concatenation/complex.template.after.php
@@ -21,10 +21,10 @@ function existingFunctionWithParameter(int $num): string {
 
 // the plugin is not responsible for verifying that the expression is correct, but rather that the behaviour
 // remains unaltered after the conversion
-$newVarFnCall1 = print_r($array, true);
-$newVarFnCall2 = nonExistingFunction();
-$newVarFnCall3 = existingFunction();
-$newVarFnCall4 = existingFunctionWithParameter(123);
+$newVarFnCall13 = print_r($array, true);
+$newVarFnCall18 = nonExistingFunction();
+$newVarFnCall23 = existingFunction();
+$newVarFnCall29 = existingFunctionWithParameter(123);
 $someVar = <<<HEREDOC_DELIMITER
-This could be $very \n complicated{$newVarFnCall1}<br /> Non-existing function:{$newVarFnCall2}<br /> Existing function:{$newVarFnCall3}<br /> Existing function with parameter (123):{$newVarFnCall4}
+This could be $very \n complicated{$newVarFnCall13}<br /> Non-existing function:{$newVarFnCall18}<br /> Existing function:{$newVarFnCall23}<br /> Existing function with parameter (123):{$newVarFnCall29}
 HEREDOC_DELIMITER;

--- a/src/test/testData/php/templates/concatenation/complex.template.after.php
+++ b/src/test/testData/php/templates/concatenation/complex.template.after.php
@@ -26,5 +26,6 @@ $newVarFnCall18 = nonExistingFunction();
 $newVarFnCall23 = existingFunction();
 $newVarFnCall29 = existingFunctionWithParameter(123);
 $someVar = <<<HEREDOC_DELIMITER
-This could be $very \n complicated{$newVarFnCall13}<br /> Non-existing function:{$newVarFnCall18}<br /> Existing function:{$newVarFnCall23}<br /> Existing function with parameter (123):{$newVarFnCall29}
+This could be $very 
+ complicated{$newVarFnCall13}<br /> Non-existing function:{$newVarFnCall18}<br /> Existing function:{$newVarFnCall23}<br /> Existing function with parameter (123):{$newVarFnCall29}
 HEREDOC_DELIMITER;

--- a/src/test/testData/php/templates/concatenation/complex.template.before.php
+++ b/src/test/testData/php/templates/concatenation/complex.template.before.php
@@ -23,7 +23,7 @@ function existingFunctionWithParameter(int $num): string {
 // remains unaltered after the conversion
 $someVar = 'This '
     . "could be $very \n"
-    . ' '
+    . ' '<caret>
     . 'complicated'
     . print_r($array, true)
     . '<br /> Non-existing function:'

--- a/src/test/testData/php/templates/concatenation/simple.template.after.php
+++ b/src/test/testData/php/templates/concatenation/simple.template.after.php
@@ -1,0 +1,5 @@
+<?php
+$a = 'a';
+$someVar = <<<HEREDOC_DELIMITER
+{$a}bc
+HEREDOC_DELIMITER;

--- a/src/test/testData/php/templates/concatenation/simple.template.before.php
+++ b/src/test/testData/php/templates/concatenation/simple.template.before.php
@@ -1,0 +1,3 @@
+<?php
+$a = 'a';
+$someVar = $a<caret> . 'b' . "c";

--- a/src/test/testData/php/templates/concatenation/with_constant.template.after.php
+++ b/src/test/testData/php/templates/concatenation/with_constant.template.after.php
@@ -1,0 +1,6 @@
+<?php
+const A = 'a';
+$newVarPhpExpression1 = A;
+$someVar = <<<HEREDOC_DELIMITER
+{$newVarPhpExpression1}bc
+HEREDOC_DELIMITER;

--- a/src/test/testData/php/templates/concatenation/with_constant.template.before.php
+++ b/src/test/testData/php/templates/concatenation/with_constant.template.before.php
@@ -1,0 +1,3 @@
+<?php
+const A = 'a';
+$someVar = A<caret> . 'b' . "c";

--- a/src/test/testData/php/templates/concatenation/with_escapings.template.after.php
+++ b/src/test/testData/php/templates/concatenation/with_escapings.template.after.php
@@ -2,10 +2,12 @@
 /**
  * this file has a string concatenations with:
  * - variables
- * - escaped single quotes
- * - escaped double quotes
+ * - escaped single quotes within single-quotes strings
+ * - escaped double quotes within double-quotes strings
+ * - "escaped" single quotes within DOUBLE-QUOTES strings (where it would not be necessary for syntax)
+ * - "escaped" double quotes within SINGLE-QUOTES strings (where it would not be necessary for syntax)
  */
 $existing = 'whatever';
 $someVar = <<<HEREDOC_DELIMITER
-if (\$('elementId').innerHTML==\\"\\") {{$existing}; }; \$('elementId').style.visibility='visible'
+{$existing}I actually escape single quotes because it is necessary: 'BLA'\nI actually escape double quotes because it is necessary: \"BLA\"\nI \'escape\' single quotes for some future processing reasons\nI \\\"escape\\\" double quotes for some future processing reasons\nI actually escape single quotes because \\n it is necessary, but I also want to print backslashes: \\'BLA\\'\nI actually escape double quotes because it is necessary, but I also want to print backslashes: \\\"BLA\\\"\nI escape dollar for no reason in a SINGLE quoted string \\\$bla , meaning I will print a backslash and a dollar\nI escape dollar for good reasons in a DOUBLE quoted string \$bla , meaning I will print no backslash but only a dollar\n
 HEREDOC_DELIMITER;

--- a/src/test/testData/php/templates/concatenation/with_escapings.template.after.php
+++ b/src/test/testData/php/templates/concatenation/with_escapings.template.after.php
@@ -9,5 +9,13 @@
  */
 $existing = 'whatever';
 $someVar = <<<HEREDOC_DELIMITER
-{$existing}I actually escape single quotes because it is necessary: 'BLA'\nI actually escape double quotes because it is necessary: \"BLA\"\nI \'escape\' single quotes for some future processing reasons\nI \\\"escape\\\" double quotes for some future processing reasons\nI actually escape single quotes because \\n it is necessary, but I also want to print backslashes: \\'BLA\\'\nI actually escape double quotes because it is necessary, but I also want to print backslashes: \\\"BLA\\\"\nI escape dollar for no reason in a SINGLE quoted string \\\$bla , meaning I will print a backslash and a dollar\nI escape dollar for good reasons in a DOUBLE quoted string \$bla , meaning I will print no backslash but only a dollar\n
+{$existing}I actually escape single quotes because it is necessary: 'BLA'
+I actually escape double quotes because it is necessary: \"BLA\"
+I \'escape\' single quotes for some future processing reasons
+I \\\"escape\\\" double quotes for some future processing reasons
+I actually escape single quotes because \\n it is necessary, but I also want to print backslashes: \\'BLA\\'
+I actually escape double quotes because it is necessary, but I also want to print backslashes: \\\"BLA\\\"
+I escape dollar for no reason in a SINGLE quoted string \\\$bla , meaning I will print a backslash and a dollar
+I escape dollar for good reasons in a DOUBLE quoted string \$bla , meaning I will print no backslash but only a dollar
+
 HEREDOC_DELIMITER;

--- a/src/test/testData/php/templates/concatenation/with_escapings.template.before.php
+++ b/src/test/testData/php/templates/concatenation/with_escapings.template.before.php
@@ -2,10 +2,21 @@
 /**
  * this file has a string concatenations with:
  * - variables
- * - escaped single quotes
- * - escaped double quotes
+ * - escaped single quotes within single-quotes strings
+ * - escaped double quotes within double-quotes strings
+ * - "escaped" single quotes within DOUBLE-QUOTES strings (where it would not be necessary for syntax)
+ * - "escaped" double quotes within SINGLE-QUOTES strings (where it would not be necessary for syntax)
  */
 $existing = 'whatever';
-$someVar = 'if<caret> ($(\'elementId\').innerHTML==\"\") {' .
-    $existing . '; }'
-    . '; $(\'elementId\').style.visibility=\'visible\'';
+$someVar =  '<caret>' . $existing .
+            'I actually escape single quotes because it is necessary: \'BLA\'' . "\n" .
+            "I actually escape double quotes because it is necessary: \"BLA\"" . "\n" .
+
+            "I \'escape\' single quotes for some future processing reasons" . "\n" .
+            'I \"escape\" double quotes for some future processing reasons' . "\n" .
+
+            'I actually escape single quotes because \n it is necessary, but I also want to print backslashes: \\\'BLA\\\'' . "\n" .
+            "I actually escape double quotes because it is necessary, but I also want to print backslashes: \\\"BLA\\\"" . "\n" .
+
+            'I escape dollar for no reason in a SINGLE quoted string \$bla , meaning I will print a backslash and a dollar' . "\n" .
+            "I escape dollar for good reasons in a DOUBLE quoted string \$bla , meaning I will print no backslash but only a dollar" . "\n";

--- a/src/test/testData/php/templates/concatenation/within_array.template.after.php
+++ b/src/test/testData/php/templates/concatenation/within_array.template.after.php
@@ -8,7 +8,9 @@ $newVarFnCall19 = functionCall();
 $arr = [
     'entry1',
     <<<HEREDOC_DELIMITER
-{$newVarPhpExpression3}a{$newVarPhpExpression5}{$newVarPhpExpression7}\n{$givenCls->value}\n End :){$newVarFnCall19}
+{$newVarPhpExpression3}a{$newVarPhpExpression5}{$newVarPhpExpression7}
+{$givenCls->value}
+ End :){$newVarFnCall19}
 HEREDOC_DELIMITER,
     'entry3'
 ];

--- a/src/test/testData/php/templates/concatenation/within_array.template.after.php
+++ b/src/test/testData/php/templates/concatenation/within_array.template.after.php
@@ -1,13 +1,14 @@
 <?php
 $givenCls = new stdClass();
 $givenCls->value = 'value of stdClass';
-$newVarPhpExpression1 = 5;
-$newVarPhpExpression2 = true;
-$newVarPhpExpression3 = null;
+$newVarPhpExpression3 = 5;
+$newVarPhpExpression5 = true;
+$newVarPhpExpression7 = null;
+$newVarFnCall19 = functionCall();
 $arr = [
     'entry1',
     <<<HEREDOC_DELIMITER
-{$newVarPhpExpression1}a{$newVarPhpExpression2}{$newVarPhpExpression3}{$givenCls->value}
+{$newVarPhpExpression3}a{$newVarPhpExpression5}{$newVarPhpExpression7}\n{$givenCls->value}\n End :){$newVarFnCall19}
 HEREDOC_DELIMITER,
     'entry3'
 ];

--- a/src/test/testData/php/templates/concatenation/within_array.template.before.php
+++ b/src/test/testData/php/templates/concatenation/within_array.template.before.php
@@ -3,6 +3,6 @@ $givenCls = new stdClass();
 $givenCls->value = 'value of stdClass';
 $arr = [
     'entry1',
-    5 . 'a' . true . null<caret>. "{$givenCls->value}",
+    5 . 'a' . true . null<caret>. "\n" . "{$givenCls->value}" . "\n End :)" . functionCall(),
     'entry3'
 ];

--- a/src/test/testData/php/templates/concatenation/within_big_indentation.template.after.php
+++ b/src/test/testData/php/templates/concatenation/within_big_indentation.template.after.php
@@ -4,9 +4,9 @@ if (true) {
         if (true) {
             if (true) {
                 $b = false;
-                $newVarPhpExpression1 = 5;
+                $newVarPhpExpression3 = 5;
                 return <<<HEREDOC_DELIMITER
-we{$newVarPhpExpression1}{$b}notbreakanyindentation
+we{$newVarPhpExpression3}{$b}notbreakanyindentation
 HEREDOC_DELIMITER;
             }
         }

--- a/src/test/testData/php/templates/echo_with_commas/simple.template.after.php
+++ b/src/test/testData/php/templates/echo_with_commas/simple.template.after.php
@@ -1,0 +1,6 @@
+<?php
+$a = 5;
+$newVarPhpExpression2 = 55;
+echo <<<HEREDOC_DELIMITER
+{$a}hello{$newVarPhpExpression2}
+HEREDOC_DELIMITER;


### PR DESCRIPTION
# TLDR;
1. Use the visitor pattern to go through the concatenation, instead of using sprintf


# Desc
## Why change from sprintf intention to tree visitor pattern? 
I am looking to implemented issue https://github.com/Tognitos/intellij-string-concat-heredoc-plugin/issues/6 
Due to how echo with commas works (see Issue for better description), I need to able to iterate through the AST tree and catch every expression individually. Also, there is no existing intention for echo with commas statement.

## However
Using sprintf was the quickest initial way to get a proper conversion, which separated text and params.
The `Sprintf` intention would still be a great option. Nothing wrong with using existing intentions.
If the use case of `echo` with comma-separated expressions wouldn't exist, I would probably keep the sprintf intention method instead
