### PR TITLE
fix(#14): Wrong escaping of double quotes when they are contained wit…

### DIFF
--- a/src/test/testData/php/templates/concatenation/with_escapings.template.after.php
+++ b/src/test/testData/php/templates/concatenation/with_escapings.template.after.php
@@ -10,11 +10,13 @@
 $existing = 'whatever';
 $someVar = <<<HEREDOC_DELIMITER
 {$existing}I actually escape single quotes because it is necessary: 'BLA'
-I actually escape double quotes because it is necessary: \"BLA\"
-I \'escape\' single quotes for some future processing reasons
-I \\\"escape\\\" double quotes for some future processing reasons
+I actually escape double quotes because it is necessary: "BLA"
+I \'escape\'
+\t\t\t single quotes for some future processing reasons
+I \\"escape\\"
+            double quotes for some future processing reasons
 I actually escape single quotes because \\n it is necessary, but I also want to print backslashes: \\'BLA\\'
-I actually escape double quotes because it is necessary, but I also want to print backslashes: \\\"BLA\\\"
+I actually escape double quotes because it is necessary, but I also want to print backslashes: \\"BLA\\"
 I escape dollar for no reason in a SINGLE quoted string \\\$bla , meaning I will print a backslash and a dollar
 I escape dollar for good reasons in a DOUBLE quoted string \$bla , meaning I will print no backslash but only a dollar
 

--- a/src/test/testData/php/templates/concatenation/with_escapings.template.before.php
+++ b/src/test/testData/php/templates/concatenation/with_escapings.template.before.php
@@ -12,8 +12,10 @@ $someVar =  '<caret>' . $existing .
             'I actually escape single quotes because it is necessary: \'BLA\'' . "\n" .
             "I actually escape double quotes because it is necessary: \"BLA\"" . "\n" .
 
-            "I \'escape\' single quotes for some future processing reasons" . "\n" .
-            'I \"escape\" double quotes for some future processing reasons' . "\n" .
+            "I \'escape\'
+\t\t\t single quotes for some future processing reasons" . "\n" .
+            'I \"escape\"
+            double quotes for some future processing reasons' . "\n" .
 
             'I actually escape single quotes because \n it is necessary, but I also want to print backslashes: \\\'BLA\\\'' . "\n" .
             "I actually escape double quotes because it is necessary, but I also want to print backslashes: \\\"BLA\\\"" . "\n" .


### PR DESCRIPTION
…hin single-quoted strings (either '' or NOWDOC)

# Fixes #14 
See #14 for more details

# Desc

Single-quoted strings were being escaped to double quotes through an existing intention. This was not bad per-se, but had the unintended faulty consequence that the double quotes contained within a single-quoted strings would be escaped. Escaping double quotes is not necessary in HEREDOC. Having them "escaped" causes HEREDOC to print additional backslashes, causing the end result to be different from the starting concatenation.